### PR TITLE
Fix DPR for swarm of quippers and sahuagin

### DIFF
--- a/src/data/monsters.ts
+++ b/src/data/monsters.ts
@@ -11576,7 +11576,7 @@ export const Monsters: Creature[] = [
                 "actionSlot": 0,
                 "freq": "at will",
                 "condition": "default",
-                "dpr": 17,
+                "dpr": 8,
                 "toHit": 3,
                 "target": "enemy with most HP",
                 "targets": 1
@@ -12803,7 +12803,7 @@ export const Monsters: Creature[] = [
                 "actionSlot": 0,
                 "freq": "at will",
                 "condition": "default",
-                "dpr": 21,
+                "dpr": 14,
                 "toHit": 5,
                 "target": "enemy with most HP",
                 "targets": 1


### PR DESCRIPTION
The swam of quippers has two damages listed, one which does and average of 14 damage and another which does an average of 7. My guess is these were added, when it is one OR the other.

For a sahuagin, I am not sure where the DRP of 17 came from. They get two attacks for a spear (4 or 5 average damage) and a bite for 3. This is a total of 7 or 8 (depending on if the spear is wielded in 2 hands)

What is the source of these DPRs? Are there others which a far off like this?