### PR TITLE
Feature/Target random enemy or ally

### DIFF
--- a/src/components/creatureForm/actionForm.tsx
+++ b/src/components/creatureForm/actionForm.tsx
@@ -79,6 +79,7 @@ const EnemyTargetOptions: Options<EnemyTarget> = [
     { value: 'enemy with highest DPR', label: 'Enemy with highest DPR' },
     { value: 'enemy with lowest AC', label: 'Enemy with lowest AC' },
     { value: 'enemy with highest AC', label: 'Enemy with highest AC' },
+    { value: 'random enemy', label: 'Random enemy' },
 ]
 
 const AllyTargetOptions: Options<AllyTarget> = [
@@ -88,6 +89,7 @@ const AllyTargetOptions: Options<AllyTarget> = [
     { value: 'ally with the highest DPR', label: 'Ally with the highest DPR' },
     { value: 'ally with the lowest AC', label: 'Ally with the lowest AC' },
     { value: 'ally with the highest AC', label: 'Ally with the highest AC' },
+    { value: 'random ally', label: 'Random ally' },
 ]
 
 const BuffDurationOptions: Options<BuffDuration> = [

--- a/src/model/enums.ts
+++ b/src/model/enums.ts
@@ -22,6 +22,7 @@ export const EnemyTargetList = [
     'enemy with highest DPR',
     'enemy with lowest AC',
     'enemy with highest AC',
+    'random enemy',
 ] as const
 export const EnemyTargetSchema = z.enum(EnemyTargetList)
 export type EnemyTarget = z.infer<typeof EnemyTargetSchema>
@@ -33,6 +34,7 @@ export const AllyTargetList = [
     'ally with the lowest AC',
     'ally with the highest AC',
     'self',
+    'random ally',
 ] as const
 export const AllyTargetSchema = z.enum(AllyTargetList)
 export type AllyTarget = z.infer<typeof AllyTargetSchema>

--- a/src/model/simulation.ts
+++ b/src/model/simulation.ts
@@ -211,10 +211,12 @@ function getNextTarget(combattant: Combattant, action: FinalAction, allies: Comb
     if (action.target === "ally with the most HP") return allies.reduce((a1, a2) => (a1.finalState.currentHP > a2.finalState.currentHP) ? a1 : a2)
     if (action.target === "ally with the least HP") return allies.reduce((a1, a2) => (a1.finalState.currentHP < a2.finalState.currentHP) ? a1 : a2)
     if (action.target === "ally with the highest DPR") return getHighestDPR(allies)
+    if (action.target === "random ally") return allies[Math.floor(Math.random() * allies.length)];
     if (action.target === "enemy with highest AC") return enemies.reduce((a1, a2) => (a1.creature.AC > a2.creature.AC) ? a1 : a2)
     if (action.target === "enemy with lowest AC") return enemies.reduce((a1, a2) => (a1.creature.AC < a2.creature.AC) ? a1 : a2)
     if (action.target === "enemy with most HP") return enemies.reduce((a1, a2) => (a1.finalState.currentHP + (a1.finalState.tempHP || 0) > a2.finalState.currentHP + (a2.finalState.tempHP || 0)) ? a1 : a2)
     if (action.target === "enemy with least HP") return enemies.reduce((a1, a2) => (a1.finalState.currentHP + (a1.finalState.tempHP || 0) < a2.finalState.currentHP + (a2.finalState.tempHP || 0)) ? a1 : a2)
+    if (action.target === "random enemy") return enemies[Math.floor(Math.random() * enemies.length)];
     /* if (action.target === "enemy with highest DPR") */ return getHighestDPR(enemies)
 }
 


### PR DESCRIPTION
The default "enemy with lowest hp" assumes that the enemy (often players) will swap out who is in front and taking damage. In many scenarios, the battle is much more chaotic, so I added a random target option for both enemy and ally.