### PR TITLE
Feature/Added conditions for enemy count 1 and enemy count > 2

### DIFF
--- a/src/components/creatureForm/actionForm.tsx
+++ b/src/components/creatureForm/actionForm.tsx
@@ -38,6 +38,8 @@ const ConditionOptions: Options<ActionCondition> = [
     { value:'is under half HP', label: 'This creature is under half its maximum HP' },
     { value:'has no THP', label: 'This creature has no temporary HP' },
     { value:'not used yet', label: 'This action has not been used yet this encounter' },
+    { value:'single enemy', label: 'Number of enemies = 1' },
+    { value:'enemy count over 2', label: 'Number of enemies > 2' },
 ]
 
 const TypeOptions: Options<ActionType> = [

--- a/src/model/enums.ts
+++ b/src/model/enums.ts
@@ -44,7 +44,9 @@ export const ActionConditionList = [
     'is available', 
     'is under half HP', 
     'has no THP', 
-    'not used yet'
+    'not used yet',
+    'single enemy',
+    'enemy count over 2'
 ] as const
 export const ActionConditionSchema = z.enum(ActionConditionList)
 export type ActionCondition = z.infer<typeof ActionConditionSchema>


### PR DESCRIPTION
It would be nice if we could make it a configurable condition, with enemy/ally count </>, = x, but that's a lot more complicated. For now though, I'm not sure if it should be; 
count = 1 and >2
or count <= 2 and >2
or count = 1 and >1,
or count =1, and =2 and >2

