### PR TITLE
Fixed debuffs not getting the displayname set.

### DIFF
--- a/src/components/simulation/encounterResult.tsx
+++ b/src/components/simulation/encounterResult.tsx
@@ -126,7 +126,7 @@ const TeamResults:FC<TeamPropType> = ({ round, team, stats }) => {
                                         <>
                                             {li.length ? li : <b>No Actions</b>}
                                             {bi.length ? <>
-                                                <br /><u>Active Buffs</u><br />
+                                                <br /><u>Active Effects</u><br />
                                                 {bi}
                                             </> : null}
                                         </>

--- a/src/model/simulation.ts
+++ b/src/model/simulation.ts
@@ -518,6 +518,7 @@ function useDebuffAction(attacker: Combattant, action: DebuffAction, target: Com
     const buffClone: Buff = clone(action.buff)
     if (buffClone.magnitude === undefined) buffClone.magnitude = 1
     buffClone.magnitude *= chanceToFail
+    buffClone.displayName = action.name;
 
     applyBuff(target, action.id, buffClone, 'min')
     


### PR DESCRIPTION
Renamed "Active Buffs" to "Active Effects", as it includes both buffs and debuffs.