### PR TITLE
Add critical damage to dice expressions

### DIFF
--- a/src/components/creatureForm/playerForm.tsx
+++ b/src/components/creatureForm/playerForm.tsx
@@ -83,7 +83,8 @@ const PlayerForm:FC<PropType> = ({ value, onChange }) => {
             <h3>Class</h3>
             <section className={styles.classes}>
                 { ClassesList.map(className => (
-                    <button 
+                    <button
+                        key={className}
                         className={`${styles.class} ${(chosenClass?.type === className) ? styles.active : ''}`}
                         onClick={() => { setClass(className) }}
                     >

--- a/src/model/simulation.ts
+++ b/src/model/simulation.ts
@@ -1,9 +1,17 @@
 import { ActionTemplates, getFinalAction } from "../data/actions"
-import { evaluateDiceFormula } from "./dice"
+import { EvaluationOptions, evaluateDiceFormula } from "./dice"
 import { ActionSlots, ActionType, CreatureCondition, CreatureConditionList } from "./enums"
 import { Action, AtkAction, Buff, BuffAction, Combattant, Creature, CreatureState, DebuffAction, DiceFormula, Encounter, EncounterResult, EncounterStats, FinalAction, HealAction, Round, SimulationResult } from "./model"
 import { clone, range } from "./utils"
 import { v4 as uuid } from 'uuid'
+
+function evaluateDamageFormula(expr: number|string, canCrit?: boolean) {
+    const standard = evaluateDiceFormula(expr, { doubleDice: false })
+    return {
+        standard,
+        critical: canCrit ? evaluateDiceFormula(expr, { doubleDice: true }) : standard,
+    }
+}
 
 // Used to update a creature's resources between encounters
 function getRemainingUses(creature: Creature, rest: 'none'|'short rest'|'long rest', oldValue?: Map<string, number>) {
@@ -422,14 +430,14 @@ function useBuffAction(buffer: Combattant, action: BuffAction, target: Combattan
 
 // Sums up all of the buffs on a given combattant, taking into account the buff's magnitude
 // e.g. getBuffs(combattant, b => b.ac, 'add') will return the total of all of the buffs which alter a creature's AC
-function getBuffs(combattant: Combattant, getter: (buff: Buff) => DiceFormula|undefined, reducer: 'add'|'mult', canCrit?: boolean): number {
+function getBuffs(combattant: Combattant, getter: (buff: Buff) => DiceFormula|undefined, reducer: 'add'|'mult', options?: EvaluationOptions): number {
     return Array.from(combattant.finalState.buffs)
         .map(([_, buff]) => {
             const expr = getter(buff)
             
             if (expr === undefined) return (reducer === 'add') ? 0 : 1
 
-            const value = evaluateDiceFormula(expr, canCrit)
+            const value = evaluateDiceFormula(expr, options)
 
             const magnitude = (buff.magnitude === undefined) ? 1 : buff.magnitude
 
@@ -541,20 +549,30 @@ function useAtkAction(attacker: Combattant, action: AtkAction, target: Combattan
     const hitChance = (1 - chanceToBeIncapacitated) * (action.useSaves ?
         calculateChanceToFail(attacker, target, action.toHit)
         : calculateHitChance(attacker, target, action.toHit))
-        
+
     const targetConditions = getConditions(target)
-    const damage = Math.max((
-            evaluateDiceFormula(action.dpr, !action.useSaves)
-            + getBuffs(attacker, b => b.damage, 'add', /* can crit: */ !action.useSaves)
-            - getBuffs(target, b => b.damageReduction, 'add', /* can not crit: */ false)
-        ), 0)
+
+    const damageMultiplier = 1
         * getBuffs(attacker, b => b.damageMultiplier, 'mult')
         * getBuffs(target, b => b.damageTakenMultiplier, 'mult')
         * (1 + targetConditions.get('Paralyzed')!)
-        
-    let actualDamage = damage * hitChance
+
+    const standardDamage = damageMultiplier * Math.max((
+        evaluateDiceFormula(action.dpr, { doubleDice: false })
+        + getBuffs(attacker, b => b.damage, 'add', { doubleDice: false })
+        - getBuffs(target, b => b.damageReduction, 'add', { doubleDice: false })
+    ), 0)
+    const criticalDamage = damageMultiplier * Math.max((
+        evaluateDiceFormula(action.dpr, { doubleDice: !action.useSaves })
+        + getBuffs(attacker, b => b.damage, 'add', { doubleDice: !action.useSaves })
+        - getBuffs(target, b => b.damageReduction, 'add', { doubleDice: false }) // negative cannot crit
+    ), 0)
+
+    /** TODO: update critChance when implementing features such as crit at 19 */
+    const critChance = 0.05;
+    let actualDamage = standardDamage * (hitChance - critChance) + criticalDamage * critChance
     if (action.useSaves && action.halfOnSave) {
-        actualDamage = damage * hitChance + (damage/2) * (1 - hitChance)
+        actualDamage = standardDamage * hitChance + (standardDamage/2) * (1 - hitChance)
     }
 
     // Apply damage to temporary hit points first


### PR DESCRIPTION
I've added the option to double damage dice in dice.ts, replace the unused `canCrit` argument with that and used it in the attack damage calculation.