### PR TITLE
Added the "No other action is available" or "low priority default" condition

### DIFF
--- a/src/components/creatureForm/actionForm.tsx
+++ b/src/components/creatureForm/actionForm.tsx
@@ -38,6 +38,7 @@ const ConditionOptions: Options<ActionCondition> = [
     { value:'is under half HP', label: 'This creature is under half its maximum HP' },
     { value:'has no THP', label: 'This creature has no temporary HP' },
     { value:'not used yet', label: 'This action has not been used yet this encounter' },
+    { value:'nothing else available', label: 'No other Action available' },
 ]
 
 const TypeOptions: Options<ActionType> = [

--- a/src/model/enums.ts
+++ b/src/model/enums.ts
@@ -44,7 +44,8 @@ export const ActionConditionList = [
     'is available', 
     'is under half HP', 
     'has no THP', 
-    'not used yet'
+    'not used yet',
+    'nothing else available'
 ] as const
 export const ActionConditionSchema = z.enum(ActionConditionList)
 export type ActionCondition = z.infer<typeof ActionConditionSchema>

--- a/src/model/simulation.ts
+++ b/src/model/simulation.ts
@@ -108,7 +108,7 @@ function matchCondition(combattant: Combattant, action: Action, allies: Combatta
     if (action.condition === 'ally at 0 HP') return (!!allies.find(ally => (ally.finalState.currentHP === 0)))
     if (action.condition === 'ally under half HP') return !!allies.find(ally => ((ally.initialState.currentHP > 0) && (ally.finalState.currentHP <= ally.creature.hp / 2)))
 
-    // Default or "is use available"
+    // Default, "is use available" or "nothing else available"
     return true
 }
 
@@ -128,8 +128,10 @@ function getActions(combattant: Combattant, allies: Combattant[], handleHeals: b
             .filter(action => isUsable(combattant, action))
             .filter(action => matchCondition(combattant, action, allies))
             .sort((action1, action2) => {
-                if (action1.condition !== "default") return -1
-                if (action2.condition !== "default") return 1
+                if (action1.condition === "nothing else available") return 1
+                if (action2.condition === "nothing else available") return -1
+                if (action1.condition === "default") return 1
+                if (action2.condition === "default") return -1
                 if (action1.freq !== "at will") return -1
                 if (action2.freq !== "at will") return 1
 


### PR DESCRIPTION
I have run into situations, especially with player characters, where it was hard to define the priorities of abilities with the current conditions. Especially if you have multiple 'default' attacks that have charges/spell slots, then 'A use of this action is available' was not enough.

I'm not sure if this is the way to go, as it might be better to just add a priority system to attacks, so it first checks the condition, then the priority and lastly the current way of sorting by name.