### PR TITLE
Added basic conditions for number of enemies

### DIFF
--- a/src/components/creatureForm/actionForm.tsx
+++ b/src/components/creatureForm/actionForm.tsx
@@ -38,6 +38,8 @@ const ConditionOptions: Options<ActionCondition> = [
     { value:'is under half HP', label: 'This creature is under half its maximum HP' },
     { value:'has no THP', label: 'This creature has no temporary HP' },
     { value:'not used yet', label: 'This action has not been used yet this encounter' },
+    { value:'enemy count one', label: 'There is only one enemy' },
+    { value:'enemy count multiple', label: 'There are at least two enemies' },
 ]
 
 const TypeOptions: Options<ActionType> = [

--- a/src/model/enums.ts
+++ b/src/model/enums.ts
@@ -44,7 +44,9 @@ export const ActionConditionList = [
     'is available', 
     'is under half HP', 
     'has no THP', 
-    'not used yet'
+    'not used yet',
+    'enemy count one',
+    'enemy count multiple'
 ] as const
 export const ActionConditionSchema = z.enum(ActionConditionList)
 export type ActionCondition = z.infer<typeof ActionConditionSchema>

--- a/src/model/simulation.ts
+++ b/src/model/simulation.ts
@@ -101,12 +101,14 @@ function isUsable(combattant: Combattant, action: FinalAction) {
 }
 
 // Checks action.condition
-function matchCondition(combattant: Combattant, action: Action, allies: Combattant[]) {
+function matchCondition(combattant: Combattant, action: Action, allies: Combattant[], enemies: Combattant[]) {
     if (action.condition === 'not used yet') return !combattant.initialState.usedActions.has(action.id)
     if (action.condition === 'has no THP') return ((combattant.initialState.tempHP === undefined) || (combattant.initialState.tempHP === 0))
     if (action.condition === 'is under half HP') return (combattant.finalState.currentHP * 2 < combattant.creature.hp)
     if (action.condition === 'ally at 0 HP') return (!!allies.find(ally => (ally.finalState.currentHP === 0)))
     if (action.condition === 'ally under half HP') return !!allies.find(ally => ((ally.initialState.currentHP > 0) && (ally.finalState.currentHP <= ally.creature.hp / 2)))
+    if (action.condition === 'enemy count one') return (enemies.filter(enemy => enemy.initialState.currentHP > 0).length == 1)
+    if (action.condition === 'enemy count multiple') return (enemies.filter(enemy => enemy.initialState.currentHP > 0).length >= 2)
 
     // Default or "is use available"
     return true
@@ -114,7 +116,7 @@ function matchCondition(combattant: Combattant, action: Action, allies: Combatta
 
 // Determines which actions a creature will use. Does not actually perform the actions.
 // The exception is heals, to avoid situations where multiple healers all heal the same creature despite having the "ally at 0 hp" condition
-function getActions(combattant: Combattant, allies: Combattant[], handleHeals: boolean, stats: Map<string, EncounterStats>): FinalAction[] {
+function getActions(combattant: Combattant, allies: Combattant[], enemies: Combattant[], handleHeals: boolean, stats: Map<string, EncounterStats>): FinalAction[] {
     const actionSlots = new Set()
     combattant.creature.actions
         .map(getFinalAction)
@@ -126,7 +128,7 @@ function getActions(combattant: Combattant, allies: Combattant[], handleHeals: b
             .map(getFinalAction)
             .filter(action => (action.actionSlot === actionSlot))
             .filter(action => isUsable(combattant, action))
-            .filter(action => matchCondition(combattant, action, allies))
+            .filter(action => matchCondition(combattant, action, allies, enemies))
             .sort((action1, action2) => {
                 if (action1.condition !== "default") return -1
                 if (action2.condition !== "default") return 1
@@ -186,7 +188,7 @@ function getNextTarget(combattant: Combattant, action: FinalAction, allies: Comb
             const dmgBonus = getBuffs(combattant, b => b.damage, 'add')
             const dmgMult = getBuffs(combattant, b => b.damageMultiplier, 'mult')
             
-            return getActions(combattant, allies, false, stats)
+            return getActions(combattant, allies, enemies, false, stats)
             .map(action => {
                 if (action.type !== "atk") return 0
                 return (evaluateDiceFormula(action.dpr) + dmgBonus) * action.targets * dmgMult
@@ -229,7 +231,7 @@ function generateActions(allies: Combattant[], enemies: Combattant[], stats: Map
     allies.forEach(ally => {
         if (ally.initialState.currentHP <= 0) return
 
-        ally.actions.push(...getActions(ally, allies, true, stats)
+        ally.actions.push(...getActions(ally, allies, enemies, true, stats)
             .map(action => ({
                 action: action, 
                 targets: new Map(),
@@ -307,7 +309,7 @@ function triggerAction(combattant: Combattant, actionSlot: keyof typeof ActionSl
         .forEach(action => {
             if (action.actionSlot !== ActionSlots[actionSlot]) return
             if (!isUsable(combattant, action)) return
-            if (!matchCondition(combattant, action, allies)) return
+            if (!matchCondition(combattant, action, allies, enemies)) return
 
             const targets: Map<string, number> = new Map()
             combattant.actions.push({ action: action, targets: targets })


### PR DESCRIPTION
I can't remember if I have made a PR for this or something similar before?

I have added targeting conditions for "Only one enemy alive" and "Two or more enemies alive", which I often need for controlling when AOE or powerful single target abilities should be used.

The flexible way of solving this, would be to have a single 'number of enemies alive' condition, and then be able to set the number. But maybe there is no need for that amount of flexibility?